### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/api-build.yaml
+++ b/.github/workflows/api-build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dgmann/document-manager/api
           username: ${{ github.actor }}

--- a/.github/workflows/app-build.yaml
+++ b/.github/workflows/app-build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dgmann/document-manager/app
           username: ${{ github.actor }}

--- a/.github/workflows/gateway-build.yaml
+++ b/.github/workflows/gateway-build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dgmann/document-manager/gateway
           username: ${{ github.actor }}

--- a/.github/workflows/m1-adapter-build.yaml
+++ b/.github/workflows/m1-adapter-build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dgmann/document-manager/m1-adapter
           username: ${{ github.actor }}

--- a/.github/workflows/processor-build.yaml
+++ b/.github/workflows/processor-build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dgmann/document-manager/pdf-processor
           username: ${{ github.actor }}

--- a/.github/workflows/watcher-build.yaml
+++ b/.github/workflows/watcher-build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dgmann/document-manager/directory-watcher
           username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore